### PR TITLE
Remove header logo image across site

### DIFF
--- a/how-to-build-web/index.html
+++ b/how-to-build-web/index.html
@@ -142,7 +142,6 @@
   <header class="site-header" id="top">
     <div class="container nav-container">
       <a href="https://s-sites.com" class="brand" aria-label="s-sites home">
-        <img src="logo.png" alt="s-sites logo" />
         <span>How-To Hub</span>
       </a>
       <nav aria-label="Primary navigation">

--- a/how-to-build-web/pages/step-1-buy-domain.html
+++ b/how-to-build-web/pages/step-1-buy-domain.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 1: Buy a Domain Name</h1>
     <p>Your identity on the web starts here. Let's get technical.</p>
   </header>

--- a/how-to-build-web/pages/step-10-setup-email.html
+++ b/how-to-build-web/pages/step-10-setup-email.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 10: Set Up Professional Email</h1>
     <p>Build trust, look legit, and stop using Gmail for business. Here's how to create email addresses on your own domain.</p>
   </header>

--- a/how-to-build-web/pages/step-2-choose-hosting.html
+++ b/how-to-build-web/pages/step-2-choose-hosting.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 2: Choose Hosting</h1>
     <p>Your domain needs a home. Let’s pick the right host for your website goals.</p>
   </header>

--- a/how-to-build-web/pages/step-3-choose-platform.html
+++ b/how-to-build-web/pages/step-3-choose-platform.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 3: Choose a Platform or Framework</h1>
     <p>This step decides how you’ll build, update, and manage your website. Choose wisely.</p>
   </header>

--- a/how-to-build-web/pages/step-4-design-layout.html
+++ b/how-to-build-web/pages/step-4-design-layout.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 4: Design Your Layout</h1>
     <p>It's time to sketch, wireframe, and style. Let’s build your structure before you build your site.</p>
   </header>

--- a/how-to-build-web/pages/step-5-add-content.html
+++ b/how-to-build-web/pages/step-5-add-content.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 5: Add Your Content</h1>
     <p>This is where the words go — the story, the pitch, the message. Let’s write the site.</p>
   </header>

--- a/how-to-build-web/pages/step-6-connect-domain.html
+++ b/how-to-build-web/pages/step-6-connect-domain.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 6: Connect Domain + Hosting</h1>
     <p>This is the part where you tell the world where your site lives. DNS, nameservers, and SSL — let’s go.</p>
   </header>

--- a/how-to-build-web/pages/step-7-seo-basics.html
+++ b/how-to-build-web/pages/step-7-seo-basics.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 7: Add Basic SEO</h1>
     <p>SEO is how people find you. It’s also where most DIYers lose steam. Here’s how to do it right, from the start.</p>
   </header>

--- a/how-to-build-web/pages/step-8-test-launch.html
+++ b/how-to-build-web/pages/step-8-test-launch.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 8: Test + Launch</h1>
     <p>Before the world sees it, you’ve got one job: make sure it actually works — and works everywhere.</p>
   </header>

--- a/how-to-build-web/pages/step-9-submit-search-engines.html
+++ b/how-to-build-web/pages/step-9-submit-search-engines.html
@@ -11,7 +11,6 @@
 </head>
 <body>
   <header class="hero">
-    <img src="../logo.png" alt="s-sites.com logo" class="logo" />
     <h1>Step 9: Submit to Search Engines</h1>
     <p>Just because your site is live doesn't mean it's visible. This step makes sure Google and Bing actually find you.</p>
   </header>

--- a/how-to-build-web/pages/style.css
+++ b/how-to-build-web/pages/style.css
@@ -53,12 +53,6 @@ header.hero::after {
   z-index: -1;
 }
 
-header.hero img.logo {
-  width: 140px;
-  height: auto;
-  margin-bottom: 1rem;
-}
-
 header.hero h1 {
   margin: 0 0 0.75rem;
   font-size: clamp(2.1rem, 4vw, 3rem);

--- a/s-sites/index.html
+++ b/s-sites/index.html
@@ -114,8 +114,7 @@
   <header class="site-header" id="top">
     <div class="container nav-container">
       <a href="https://s-sites.com/" class="brand" aria-label="s-sites home">
-        <img src="logo.png" alt="s-sites logo" />
-        <span> s-sites </span>
+        <span>s-sites</span>
       </a>
       <nav aria-label="Primary navigation">
         <a href="#services">Hands-Free Build</a>


### PR DESCRIPTION
## Summary
- remove the logo.png image from the main s-sites header and leave a text brand label
- drop the header logo from the how-to hub landing page header so only the navigation title remains
- eliminate the logo image in each how-to step page hero and clean up the unused `.logo` styling

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68cfe7f81bbc8332bf1e8ee1a23f0ff9